### PR TITLE
Removes 3 column card lists in favor of 2

### DIFF
--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -37,7 +37,7 @@
 
       <h2 class="text-sm font-medium">Just a moment...</h2>
     </div>
-    <div class="grid grid-cols-1 gap-6 px-6 pb-8 md:grid-cols-2 lg:grid-cols-3 lg:gap-8" id="searchResults">
+    <div class="grid grid-cols-1 gap-6 px-6 pb-8 md:grid-cols-2 lg:gap-8" id="searchResults">
     </div>
 
   </div>

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -18,7 +18,7 @@
   </div>
 
   <div class="container mx-auto">
-    <div class="grid grid-cols-1 gap-6 px-6 pb-8 md:grid-cols-2 lg:grid-cols-3 lg:gap-8">
+    <div class="grid grid-cols-1 gap-6 px-6 pb-8 md:grid-cols-2 lg:gap-8">
       {{ range .Paginator.Pages.ByDate.Reverse }}
         {{ partial "session-card.html" .}}
       {{ end }}

--- a/layouts/shortcodes/upcoming-events.html
+++ b/layouts/shortcodes/upcoming-events.html
@@ -1,7 +1,7 @@
 {{ $upcoming := where (where .Site.RegularPages.Reverse "Section" "events") ".Date" "ge" now }}
 {{ if ne (len $upcoming) 0 }}
   <div class="container mx-auto">
-    <div class="grid grid-cols-1 gap-6 px-6 pb-8 md:grid-cols-2 lg:grid-cols-3 lg:gap-8">
+    <div class="grid grid-cols-1 gap-6 px-6 pb-8 md:grid-cols-2 lg:gap-8">
       {{ range $upcoming }}
         {{ partial "meetup-card" . }}
       {{ end }}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -153,13 +153,6 @@ if (carousel) {
           slidesToShow: 2,
           slidesToScroll: 2,
         }
-      },
-      {
-        breakpoint: 1024,
-        settings: {
-          slidesToShow: 3,
-          slidesToScroll: 3,
-        }
       }
     ];
   }


### PR DESCRIPTION
This swaps all 3 column grids of cards to 2 columns. This makes cards bigger, but also less prone to breakage. It also highlights the excellent session images more.

Click tests were performed. No noticeable issues.